### PR TITLE
SSH Key generation now includes ssh pubkey fingerprint generation

### DIFF
--- a/ci/release_notes.md
+++ b/ci/release_notes.md
@@ -1,0 +1,6 @@
+#Improvements
+
+
+- When using `safe ssh`, the data inserted into vault will now also
+  include the ssh fingerprint of the pubkey (similar to what is returned
+  via `ssh-keygen -lf <pubkey>`.

--- a/main.go
+++ b/main.go
@@ -478,7 +478,7 @@ func main() {
 			if err != nil && err != vault.NotFound {
 				return err
 			}
-			if err = s.SSHKey(bits); err != nil {
+			if err = s.RSAKey(bits); err != nil {
 				return err
 			}
 			if err = v.Write(path, s); err != nil {

--- a/vault/rsa.go
+++ b/vault/rsa.go
@@ -1,35 +1,35 @@
 package vault
 
 import (
-	"encoding/pem"
+	"crypto/rand"
 	"crypto/rsa"
 	"crypto/x509"
-	"crypto/rand"
+	"encoding/pem"
 )
 
-func rsakey(bits int) (string, string, error) {
+func rsakey(bits int) (string, string, string, error) {
 	key, err := rsa.GenerateKey(rand.Reader, bits)
 	if err != nil {
-		return "", "", err
+		return "", "", "", err
 	}
 
 	private := pem.EncodeToMemory(
 		&pem.Block{
-			Type: "RSA PRIVATE KEY",
+			Type:  "RSA PRIVATE KEY",
 			Bytes: x509.MarshalPKCS1PrivateKey(key),
 		},
 	)
 
 	b, err := x509.MarshalPKIXPublicKey(key.Public())
 	if err != nil {
-		return "", "", err
+		return "", "", "", err
 	}
 	public := pem.EncodeToMemory(
 		&pem.Block{
-			Type: "RSA PUBLIC KEY",
+			Type:  "RSA PUBLIC KEY",
 			Bytes: b,
 		},
 	)
 
-	return string(private), string(public), nil
+	return string(private), string(public), "", nil
 }

--- a/vault/secret.go
+++ b/vault/secret.go
@@ -8,11 +8,11 @@ import (
 // A Secret contains a set of key/value pairs that store anything you
 // want, including passwords, RSAKey keys, usernames, etc.
 type Secret struct {
-	data map[string] string
+	data map[string]string
 }
 
 func NewSecret() *Secret {
-	return &Secret{ make(map[string] string) }
+	return &Secret{make(map[string]string)}
 }
 
 func (s Secret) MarshalJSON() ([]byte, error) {
@@ -45,12 +45,15 @@ func (s *Secret) Password(key string, length int) {
 	s.data[key] = random(length)
 }
 
-func (s *Secret) keypair(private, public string, err error) error {
+func (s *Secret) keypair(private, public string, fingerprint string, err error) error {
 	if err != nil {
 		return err
 	}
 	s.data["private"] = private
-	s.data["public"]  = public
+	s.data["public"] = public
+	if fingerprint != "" {
+		s.data["fingerprint"] = fingerprint
+	}
 	return nil
 }
 


### PR DESCRIPTION
When using `safe ssh`, the data inserted into vault will now also
include the ssh fingerprint of the pubkey (similar to what is returned
via `ssh-keygen -lf <pubkey>`.