### PR TITLE
Generate a crypt() compatible sha-512 hash for `safe gen`

### DIFF
--- a/ci/release_notes.md
+++ b/ci/release_notes.md
@@ -1,0 +1,4 @@
+#Improvements
+
+- When using `safe gen`, the data inserted into the vault will now also
+  include a sha-512 crypt()-compatible hash of the password generated.

--- a/vault/secret.go
+++ b/vault/secret.go
@@ -2,7 +2,10 @@ package vault
 
 import (
 	"encoding/json"
+	"fmt"
 	"github.com/ghodss/yaml"
+	"github.com/kless/osutil/user/crypt/sha512_crypt"
+	"os"
 )
 
 // A Secret contains a set of key/value pairs that store anything you
@@ -43,6 +46,17 @@ func (s *Secret) Set(key, value string) {
 // Password creates and stores a new randomized password.
 func (s *Secret) Password(key string, length int) {
 	s.data[key] = random(length)
+	s.data[key+"-crypt"] = crypt(s.data[key])
+}
+
+func crypt(pass string) string {
+	c := sha512_crypt.New()
+	sha, err := c.Generate([]byte(pass), []byte("$6$"+random(16)))
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Error generating crypt for password: %s\n", err)
+		return ""
+	}
+	return sha
 }
 
 func (s *Secret) keypair(private, public string, fingerprint string, err error) error {


### PR DESCRIPTION
`safe gen` now generates a key suffixed by '-crypt' that is a
sha-512 based hash of the password, for use with crypt().