### PR TITLE
This PR adds feature to export secrets in natural format

### DIFF
--- a/vault/vault.go
+++ b/vault/vault.go
@@ -154,23 +154,44 @@ func (v *Vault) Read(path string) (secret *Secret, err error) {
 		}
 		raw = map[string]interface{}{key: val}
 	}
-
-	for k, v := range raw {
-		if (key != "" && k == key) || key == "" {
-			if s, ok := v.(string); ok {
-				secret.data[k] = s
-			} else {
-				var b []byte
-				b, err = json.Marshal(v)
-				if err != nil {
-					return
+	secret.data = raw
+	/*
+		for k, v := range raw {
+			if (key != "" && k == key) || key == "" {
+				if s, ok := v.(string); ok {
+					secret.data[k] = s
+				} else {
+					var b []byte
+					b, err = json.Marshal(v)
+					if err != nil {
+						return
+					}
+					secret.data[k] = string(b)
 				}
-				secret.data[k] = string(b)
 			}
 		}
-	}
-
+	*/
 	return
+}
+
+
+
+func (v *Vault) DataAsString(in *Secret) (out *Secret, err error) {
+	out = in
+
+	for k, v := range in.data {
+		if s, ok := v.(string); ok {
+			out.data[k] = s
+		} else {
+			var b []byte
+			b, err = json.Marshal(v)
+			if err != nil {
+				return
+			}
+			out.data[k] = string(b)
+		}
+	}
+	return out, nil
 }
 
 // List returns the set of (relative) paths that are directly underneath


### PR DESCRIPTION
This PR is addressing #235  

Add enhanchements to safe export and import   functions:

- It is possible now export without converting Data key values to string. If this option is used then export format is not compatible with v2 format.
- It is now possible to import with append only mode - this will take latest Alive version from import file and checks if this data matches to current data in vault. If not then it will be added as next version. This is useful when you want only to add newest values to vault and not kill your entire existing history for secret.

Thanks,
Siim